### PR TITLE
fix(qudarap): prevent call to undefined by guarding with a macro

### DIFF
--- a/qudarap/QEvt.cc
+++ b/qudarap/QEvt.cc
@@ -1360,7 +1360,9 @@ NP* QEvt::gatherComponent_(unsigned cmp) const
     switch(cmp)
     {
         //case SCOMP_GENSTEP:     a = getGenstep()     ; break ;
+#ifndef PRODUCTION
         case SCOMP_GENSTEP:       a = gatherGenstepFromDevice() ; break ;
+#endif
         case SCOMP_INPHOTON:      a = getInputPhoton()          ; break ;
         case SCOMP_PHOTON:        a = gatherPhoton()            ; break ;
         case SCOMP_PHOTONLITE:    a = gatherPhotonLite()        ; break ;


### PR DESCRIPTION
See qudarap/QEvt.hh

 ```cpp
 struct QUDARAP_API QEvt : public SCompProvider
 {
 ...
 #ifndef PRODUCTION
 ...
     NP*      gatherGenstepFromDevice() const ;
 ...
 #endif
 ...
 };
 ```